### PR TITLE
Solved compilation error for ESP8266 Node MCU v3 error for functions tha…

### DIFF
--- a/DFRobot_ID809.cpp
+++ b/DFRobot_ID809.cpp
@@ -349,6 +349,8 @@ uint8_t DFRobot_ID809::getFingerImage(uint8_t *image)
        memcpy(image+i*496,tempData+2,496);
   }
   free(tempData);
+
+  return ERR_SUCCESS;
 }
 uint8_t DFRobot_ID809::getQuarterFingerImage(uint8_t *image){
 
@@ -385,6 +387,7 @@ uint8_t DFRobot_ID809::getQuarterFingerImage(uint8_t *image){
        memcpy(image+i*496,tempData+2,496);
   }
   free(tempData);
+  return ERR_SUCCESS;
 
 }
 uint8_t DFRobot_ID809::downLoadImage(uint16_t id,uint8_t * temp)
@@ -453,6 +456,7 @@ uint8_t DFRobot_ID809::receiveImageData(uint8_t * image){
   if(ret != ERR_SUCCESS) {
     return ERR_ID809;
   }
+  return ERR_SUCCESS;
 
 }
 String DFRobot_ID809::getModuleSN(){


### PR DESCRIPTION
…t were supposed to return values but did not.

Worked on the compilation errors that I encountered due to the -Werror=return-type flag, while compiling the library to work with ESP 8266. The functions getFingerImage(uint8_t*), getQuarterFingerImage(uint8_t*), and receiveImageData(uint8_t*) are declared to return a uint8_t value, but they reach the end of the function without returning any value.

I fiedx the issue, by adding appropriate return values to these functions. Please check it out test it to see if the changes can be intergrated to save time for many people.